### PR TITLE
Remove `synchronize` as a recommended trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ on:
       - opened
       - edited
       - reopened
-      - synchronize
   schedule:
     - cron: '0 0 * * *' # schedule daily check
 


### PR DESCRIPTION
The `synchronize` event is triggered when `HEAD` of the source branch changes: [ref](https://github.com/github/docs/issues/2257#issuecomment-772884922).

Since this action only triggers on text in the issue _body_, a `synchronize` event will never result in a change to dependent issues. We can save clients some GitHub Actions execution time by not triggering on this event.