### PR TITLE
Add FAQ with cross-repo-dependencies guide

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,54 @@
+# Dependent-Issues FAQ
+
+## Use cross-repository dependencies within an organization
+
+1. Setup the action
+   
+    Setup the dependent-issues action in the repository, where youd like to create   issues and pull requests, that needs to use issues or pull-requests from a other repository within your organization.
+   
+    Remember to setup
+    ```yml
+    on:
+      schedule:
+        - cron: '0 0 * * *'
+     ```
+    to regulary check the status of referenced issues in other repositories. Adjust the cron-schedule to your personal needs.
+
+2. Create a new PAT
+   
+    The default setup of dependent-issues uses the pre-configured `GITHUB_TOKEN`, but that only enables access to the repository, in which the action is setup.
+    Because of that, you need to create a new PAT (Personal Access Token). Consider using the organization account, to create the PAT.
+
+    Follow the official documentation to create a new PAT:
+
+    [https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
+
+    When setting up the new PAT, you need to to grant `repo` permissions. Explanations for each permission can be found in the official documentation:
+
+    [https://docs.github.com/en/developers/apps/scopes-for-oauth-apps](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps)
+
+3. Add a new secret in GitHub to access the PAT within the action-workflow
+
+    Follow the instructions under [https://docs.github.com/en/actions/reference/authentication-in-a-workflow#granting-additional-permissions](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#granting-additional-permissions) to add a new secret to the repository.
+
+4. Integrate the secret in the dependent-issue workflow
+
+    Replace the usage of the `GITHUB_TOKEN` with your secret:
+
+    ```yml
+    jobs:
+      check:
+        steps:
+          env:
+            GITHUB_TOKEN: ${{ secrets.YOUR_NEW_TOKEN }}
+    ```
+
+    > Always use the GitHub secret-management to store your PATs! Never put secrets directly in your repository-sourcecode!
+
+5. Reference issues and pull-requests from other organization repositories
+
+    Reference the issue or pull-request with the URL like the following example:
+
+    ```md
+    Depends on https://github.com/z0al/dependent-issues/pull/1
+    ```

--- a/FAQ.md
+++ b/FAQ.md
@@ -4,7 +4,7 @@
 
 1. Setup the action
    
-    Setup the action in the repository, where you'd like to create issues and pull requests, that need to use issues or pull requests from another repository within your organization.
+    Set up the action in the repository, where you'd like to create issues and pull requests, that need to use issues or pull requests from another repository within your organization.
    
     Remember to setup
     ```yml
@@ -12,18 +12,18 @@
       schedule:
         - cron: '0 0 * * *'
      ```
-    to regulary check the status of referenced issues in other repositories. Adjust the cron-schedule to your personal needs.
+    to regularly check the status of referenced issues in other repositories. Adjust the cron-schedule to your personal needs.
 
 2. Create a new PAT
    
-    The default setup of dependent-issues uses the pre-configured `GITHUB_TOKEN`, but that only enables access to the repository, in which the action is setup.
+    The default setup uses the pre-configured `GITHUB_TOKEN`, but that only enables access to the repository, in which the action is set up.
     Because of that, you need to create a new PAT (Personal Access Token). Consider using the organization account, to create the PAT.
 
     Follow the official documentation to create a new PAT:
 
     [https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
 
-    When setting up the new PAT, you need to to grant `repo` permissions. Explanations for each permission can be found in the official documentation:
+    When setting up the new PAT, you need to grant `repo` permissions. Explanations for each permission can be found in the official documentation:
 
     [https://docs.github.com/en/developers/apps/scopes-for-oauth-apps](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps)
 
@@ -43,9 +43,9 @@
             GITHUB_TOKEN: ${{ secrets.YOUR_NEW_TOKEN }}
     ```
 
-    > Always use the GitHub secret-management to store your PATs! Never put secrets directly in your repository-sourcecode!
+    > Always use the GitHub secret-management to store your PATs! Never put secrets directly in your repository-source code!
 
-5. Reference issues and pull-requests from other organization repositories
+5. Reference issues and pull requests from other organization repositories
 
     Reference the issue or pull-request with the URL like the following example:
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,10 +1,10 @@
-# Dependent-Issues FAQ
+# Frequently Asked Questions (FAQs)
 
-## Use cross-repository dependencies within an organization
+## Using cross-repository dependencies within an organization
 
 1. Setup the action
    
-    Setup the dependent-issues action in the repository, where youd like to create   issues and pull requests, that needs to use issues or pull-requests from a other repository within your organization.
+    Setup the action in the repository, where you'd like to create issues and pull requests, that need to use issues or pull requests from another repository within your organization.
    
     Remember to setup
     ```yml

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Here how it can look like in practice:
 
 - **GITHUB_TOKEN** (Required): The token to use to make API calls to GitHub.
 
+## FAQ
+
+Trouble setting up Dependent Issues? Check the [FAQ](./FAQ.md).
+
 ## Changelog
 
 - **March 20, 2021:** To avoid unnecessary failure due to [insufficient permissions][dependabot-change] on Dependabot PRs, all Dependabot issues and pull requests are now ignored. This behavior is not configurable.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here how it can look like in practice:
 
 ## FAQ
 
-Trouble setting up Dependent Issues? Check the [FAQ](./FAQ.md).
+Trouble setting up the action? Check the [FAQ](./FAQ.md).
 
 ## Changelog
 


### PR DESCRIPTION
To make the setup of the action for cross-repositorie simpler, add a FAQ with a simple instruction on how to adjust the action-setup and add a PAT.

@z0al Please check the pull-request carefully. I am not that proficient with GitHub-Actions. Also, my english isn't the best ;D. If there are any mistakes or unsightlies, please don't hesitate to request further changes.

Belongs to #83
Resolves #108