### PR TITLE
chore(action.yaml): add ignore_dependabot input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,6 +17,11 @@ inputs:
     description: Enable checking for dependencies in issues
     default: off
 
+  ignore_dependabot:
+    required: false
+    description: Ignore Dependabot PRs.
+    default: off
+
   keywords:
     required: false
     description: A comma-separated list of keywords


### PR DESCRIPTION
Add the `ignore_dependabot` input, which ought to suppress the warning.

Closes #440 