### PR TITLE
chore(action.yaml): use node v16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -33,5 +33,5 @@ inputs:
       By **[Dependent Issues](https://github.com/z0al/dependent-issues)** (🤖). Happy coding!
 
 runs:
-  using: node12
+  using: node16
   main: ./index.js


### PR DESCRIPTION
Bump action to run on node v.16

Closes #535 